### PR TITLE
fix: update gpuIds to ADA_24

### DIFF
--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -7,7 +7,7 @@
   "config": {
     "runsOn": "GPU",
     "containerDiskInGb": 20,
-    "gpuIds": "NVIDIA GeForce RTX 4090",
+    "gpuIds": "ADA_24",
     "gpuCount": 1,
     "allowedCudaVersions": [
       "12.7",


### PR DESCRIPTION
### Motivation

- Updated gpuIds in .runpod/hub.json from 'NVIDIA GeForce RTX 4090' to 'ADA_24' to match the correct GPU identifier format
- This change ensures proper GPU selection and compatibility in the RunPod environment

### Issues closed

No specific issues were referenced for this change.